### PR TITLE
Enable exporting fetched data to Excel-compatible file

### DIFF
--- a/index.html
+++ b/index.html
@@ -321,18 +321,21 @@
 
 				<div id="content-data" class="content">
 					<h2>Pobrane Dane</h2>
-					<div class="filters">
-						<button class="filter-button" data-status="all">Wszystkie</button>
-						<button class="filter-button" data-status="A">Zaakceptowane</button>
-						<button class="filter-button" data-status="R">Odrzucone</button>
-						<button class="filter-button" data-status="C">
-							Zanieczyszczone
-						</button>
-					</div>
-					<div id="fetched_data"></div>
-					<div id="pagination"></div>
-					<!-- Kontener na paginację -->
-				</div>
+                                        <div class="filters">
+                                                <button class="filter-button" data-status="all">Wszystkie</button>
+                                                <button class="filter-button" data-status="A">Zaakceptowane</button>
+                                                <button class="filter-button" data-status="R">Odrzucone</button>
+                                                <button class="filter-button" data-status="C">
+                                                        Zanieczyszczone
+                                                </button>
+                                        </div>
+                                        <div class="actions">
+                                                <button id="export_data">Eksportuj do Excel</button>
+                                        </div>
+                                        <div id="fetched_data"></div>
+                                        <div id="pagination"></div>
+                                        <!-- Kontener na paginację -->
+                                </div>
 
 				<div id="content-reports" class="content">
 					<h2>Raporty</h2>

--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
-const { app, BrowserWindow, Menu } = require('electron'); // Dodano Menu
+const { app, BrowserWindow, Menu, ipcMain, dialog } = require('electron'); // Dodano Menu
+const fs = require('fs');
 const path = require('path');
 
 // Wyłączenie menu aplikacji
@@ -7,14 +8,38 @@ Menu.setApplicationMenu(null);
 let mainWindow;
 
 app.on('ready', () => {
-	mainWindow = new BrowserWindow({
-		width: 1200,
-		height: 800,
-		webPreferences: {
-			nodeIntegration: true, // Włącz integrację Node.js
-			contextIsolation: false, // Wyłącz izolację kontekstu
-		},
-	});
+        mainWindow = new BrowserWindow({
+                width: 1200,
+                height: 800,
+                webPreferences: {
+                        nodeIntegration: true, // Włącz integrację Node.js
+                        contextIsolation: false, // Wyłącz izolację kontekstu
+                },
+        });
 
-	mainWindow.loadFile('index.html');
+        mainWindow.loadFile('index.html');
+});
+
+ipcMain.handle('export-data-to-csv', async (event, data) => {
+        const { canceled, filePath } = await dialog.showSaveDialog({
+                title: 'Zapisz dane',
+                defaultPath: 'dane.csv',
+                filters: [
+                        { name: 'CSV Files', extensions: ['csv'] },
+                        { name: 'All Files', extensions: ['*'] },
+                ],
+        });
+
+        if (canceled || !filePath) {
+                return { canceled: true };
+        }
+
+        const headers = ['date', 'machine_number', 'program_number', 'status', 'weight'];
+        const csvRows = [
+                headers.join(';'),
+                ...data.map((row) => headers.map((h) => row[h] ?? '').join(';')),
+        ];
+
+        fs.writeFileSync(filePath, csvRows.join('\n'));
+        return { canceled: false, filePath };
 });


### PR DESCRIPTION
## Summary
- add "Eksportuj do Excel" button in Pobrane Dane section
- allow users to save filtered data set to a CSV file via Electron dialog
- track current filters so exports respect them

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68933acfd4cc832d9fcd3e40e3e1b64b