### PR TITLE
Export data with seconds in Excel

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,5 @@
 const { app, BrowserWindow, Menu, ipcMain, dialog } = require('electron'); // Dodano Menu
 const fs = require('fs');
-const path = require('path');
 
 // Wyłączenie menu aplikacji
 Menu.setApplicationMenu(null);
@@ -20,12 +19,12 @@ app.on('ready', () => {
         mainWindow.loadFile('index.html');
 });
 
-ipcMain.handle('export-data-to-csv', async (event, data) => {
+ipcMain.handle('export-data-to-excel', async (event, data) => {
         const { canceled, filePath } = await dialog.showSaveDialog({
                 title: 'Zapisz dane',
-                defaultPath: 'dane.csv',
+                defaultPath: 'dane.xls',
                 filters: [
-                        { name: 'CSV Files', extensions: ['csv'] },
+                        { name: 'Excel Files', extensions: ['xls'] },
                         { name: 'All Files', extensions: ['*'] },
                 ],
         });
@@ -35,11 +34,28 @@ ipcMain.handle('export-data-to-csv', async (event, data) => {
         }
 
         const headers = ['date', 'machine_number', 'program_number', 'status', 'weight'];
-        const csvRows = [
-                headers.join(';'),
-                ...data.map((row) => headers.map((h) => row[h] ?? '').join(';')),
-        ];
 
-        fs.writeFileSync(filePath, csvRows.join('\n'));
+        const headerRow =
+                '<tr>' + headers.map((h) => `<th>${h}</th>`).join('') + '</tr>';
+
+        const rows = data
+                .map((row) => {
+                        return (
+                                '<tr>' +
+                                `<td style="mso-number-format:'yyyy-mm-dd hh:mm:ss'">${
+                                        row.date ?? ''
+                                }</td>` +
+                                `<td>${row.machine_number ?? ''}</td>` +
+                                `<td>${row.program_number ?? ''}</td>` +
+                                `<td>${row.status ?? ''}</td>` +
+                                `<td>${row.weight ?? ''}</td>` +
+                                '</tr>'
+                        );
+                })
+                .join('');
+
+        const htmlContent = `<!DOCTYPE html><html><head><meta charset="UTF-8" /></head><body><table>${headerRow}${rows}</table></body></html>`;
+
+        fs.writeFileSync(filePath, htmlContent, 'utf8');
         return { canceled: false, filePath };
 });

--- a/renderer.js
+++ b/renderer.js
@@ -687,7 +687,7 @@ document.getElementById('export_data').addEventListener('click', async () => {
         }
         try {
                 const result = await ipcRenderer.invoke(
-                        'export-data-to-csv',
+                        'export-data-to-excel',
                         currentData
                 );
                 if (result.canceled) {


### PR DESCRIPTION
## Summary
- generate an Excel file instead of CSV, applying `yyyy-mm-dd hh:mm:ss` so seconds are visible
- renderer invokes the new export handler

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689432a29264832d8665cfe89864f670